### PR TITLE
Update readme on useState

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ open Feliz.Router
 
 [<ReactComponent>]
 let Router() =
-    let (currentUrl, updateUrl) = React.useState(Router.currentUrl())
+    let (currentUrl, updateUrl) = React.useState(Router.currentUrl)
     React.router [
         router.onUrlChanged updateUrl
         router.children [
@@ -133,7 +133,7 @@ let parseUrl = function
 
 [<ReactComponent>]
 static member Router() =
-    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl()))
+    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl))
     let currentPage =
         match pageUrl with
         | Home -> Html.h1 "Home"


### PR DESCRIPTION
### Problem
I noticed that in the docs the useState is as follows
> let (currentUrl, updateUrl) = Feliz.React.useState(Feliz.Router.Router.currentUrl())

However there is a type mismatch with the useState, since it requires a `unit -> 'T`, resulting in
> let (currentUrl, updateUrl) = Feliz.React.useState(Feliz.Router.Router.currentUrl)

### Pictures

![Screenshot from 2021-09-25 21-11-51](https://user-images.githubusercontent.com/14153897/134788983-e03e8c3d-ba65-41c7-ae41-9c79c982737c.png)
![Screenshot from 2021-09-25 21-14-02](https://user-images.githubusercontent.com/14153897/134788984-58488a26-3ef5-43cc-8a47-d303fec3d1bb.png)
![Screenshot from 2021-09-25 21-14-28](https://user-images.githubusercontent.com/14153897/134788986-7969848b-6893-42d9-b7db-18658f591752.png)
